### PR TITLE
Add workflow dispatch trigger

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,6 +8,8 @@ on:
     branches: [ staging, main ]
   pull_request:
     branches: [ staging, main ]
+  workflow_dispatch:
+    
 
 jobs:
   build:


### PR DESCRIPTION
### What does this PR do?
 - Implement workflow dispatch

### What tasks were done?
 - Add workflow dispatch command for manual trigger
 
### Reason
- I would be able to trigger workflows without having to make empty commits as it currently doesn't work. `git commit --allow-empty -m ""` This is so because I have been trying to trigger a workflow again without making changes to the code base at all. 